### PR TITLE
docs(cn): fix a typo and improve accuracy

### DIFF
--- a/content/docs/code-splitting.md
+++ b/content/docs/code-splitting.md
@@ -184,7 +184,7 @@ function handleTabSelect(tab) {
 }
 ```
 
-此处代码会告知 React，将标签设置为 `'comments'`，并非一个紧急更新。而是一个 [transition](/docs/react-api.html#transitions)，可能需要一些实际。然后 React 会保留旧的 UI 并进行交互，当它准备好时，会切换为 `<Comments />`，具体请参阅 [Transitions](/docs/react-api.html#transitions) 以了解更多相关信息。
+此处代码会告知 React，将标签切换为 `'comments'` 不会标记为紧急更新，而是标记为需要一些准备时间的 [transition](/docs/react-api.html#transitions)。然后 React 会保留旧的 UI 并进行交互，当它准备好时，会切换为 `<Comments />`，具体请参阅 [Transitions](/docs/react-api.html#transitions) 以了解更多相关信息。
 
 ### 异常捕获边界（Error boundaries）{#error-boundaries}
 


### PR DESCRIPTION
原文:
> Here, you tell React that setting tab to `'comments'` is not an urgent update, but is a [transition](https://reactjs.org/docs/react-api.html#transitions) that may take some time. React will then keep the old UI in place and interactive, and will switch to showing `<Comments />` when it is ready. See [Transitions](https://reactjs.org/docs/react-api.html#transitions) for more info.

原翻译:
> 此处代码会告知 React，将标签设置为 `'comments'`，并非一个紧急更新。而是一个 [transition](https://zh-hans.reactjs.org/docs/react-api.html#transitions)，可能需要一些实际。然后 React 会保留旧的 UI 并进行交互，当它准备好时，会切换为 `<Comments />`，具体请参阅 [Transitions](https://zh-hans.reactjs.org/docs/react-api.html#transitions) 以了解更多相关信息。

现修改为:
> 此处代码会告知 React，将标签切换为 `'comments'` 不会标记为紧急更新，而是标记为需要一些准备时间的 [transition](https://zh-hans.reactjs.org/docs/react-api.html#transitions)。然后 React 会保留旧的 UI 并进行交互，当它准备好时，会切换为 `<Comments />`，具体请参阅 [Transitions](https://zh-hans.reactjs.org/docs/react-api.html#transitions) 以了解更多相关信息。
---
- setting tab to `'comments'` : 根据前文这里应该理解为**切换标签为...的事件**，而不应直译作**将标签设置为...**

- is not an urgent update, but is a transition : 根据 `startTransition` 的作用可以理解为react将被 `startTransition` 包裹的回调函数**标记**为 transitions 而不是 urgent update
> `React.startTransition` lets you mark updates inside the provided callback as transitions.
- may take some time : 这里指的是被标记为 transition 的回调函数/事件，从并发执行到渲染更新的事件，这个过程所花费的事件译作**准备时间**较为妥当